### PR TITLE
Add cstdint include

### DIFF
--- a/scd/v_2_scd.h
+++ b/scd/v_2_scd.h
@@ -18,6 +18,7 @@
 #ifndef SCD_V_2_SCD_H_
 #define SCD_V_2_SCD_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <utility>


### PR DESCRIPTION
My compiler won't compile TinyGarble because of this missing header. Seems cstdint is not pulled in transitively on all systems.